### PR TITLE
Fix setting max lines via code

### DIFF
--- a/app/src/main/java/at/blogc/android/activities/MainActivity.java
+++ b/app/src/main/java/at/blogc/android/activities/MainActivity.java
@@ -39,6 +39,9 @@ public class MainActivity extends AppCompatActivity
         final ExpandableTextView expandableTextView = (ExpandableTextView) this.findViewById(R.id.expandableTextView);
         final Button buttonToggle = (Button) this.findViewById(R.id.button_toggle);
 
+        // set max lines via code
+        expandableTextView.setMaxLines(3);
+    
         // set animation duration via code, but preferable in your layout files by using the animation_duration attribute
         expandableTextView.setAnimationDuration(750L);
 

--- a/expandabletextview/src/main/java/at/blogc/android/views/ExpandableTextView.java
+++ b/expandabletextview/src/main/java/at/blogc/android/views/ExpandableTextView.java
@@ -43,7 +43,7 @@ public class ExpandableTextView extends TextView
     private TimeInterpolator expandInterpolator;
     private TimeInterpolator collapseInterpolator;
 
-    private final int maxLines;
+    private int maxLines;
     private long animationDuration;
     private boolean animating;
     private boolean expanded;
@@ -101,7 +101,14 @@ public class ExpandableTextView extends TextView
            return -1;
         }
     }
-
+	
+	@Override
+	public void setMaxLines(int maxLines)
+	{
+		super.setMaxLines(maxLines);
+		this.maxLines = maxLines;
+	}
+    
     /**
      * Toggle the expanded state of this {@link ExpandableTextView}.
      * @return true if toggled, false otherwise.
@@ -139,7 +146,7 @@ public class ExpandableTextView extends TextView
             this.collapsedHeight = this.getMeasuredHeight();
 
             // set maxLines to MAX Integer, so we can calculate the expanded height
-            this.setMaxLines(Integer.MAX_VALUE);
+            super.setMaxLines(Integer.MAX_VALUE);
 
             // get expanded height
             this.measure
@@ -232,7 +239,7 @@ public class ExpandableTextView extends TextView
                 public void onAnimationEnd(final Animator animation)
                 {
                     // set maxLines to original value
-                    ExpandableTextView.this.setMaxLines(ExpandableTextView.this.maxLines);
+                    ExpandableTextView.super.setMaxLines(ExpandableTextView.this.maxLines);
 
                     // if fully collapsed, set height to WRAP_CONTENT, because when rotating the device
                     // the height calculated with this ValueAnimator isn't correct anymore


### PR DESCRIPTION
This pr enables setting `maxLines` via code. Usage is shown is sample activity. It also fixes #13 and fixes #8.